### PR TITLE
removes default header info image

### DIFF
--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -316,13 +316,13 @@ const Header = ({
                 {showInfoBox && (
                   <Col md={3} mdOffset={1}>
                     <InfoBox type={type}>
-                      <Link to={`#${linkToGallery}`}>
+                      {training.image && (
                         <Image
                           src={training.image || SMALL_CLASSROOM}
                           width="100%"
                           alt="React GraphQL Academy coach Alex assists a student, being next to them, inspecting their code and helping them on their learning path."
                         />
-                      </Link>
+                      )}
 
                       <Ul unstyled>
                         <Li>

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -318,7 +318,7 @@ const Header = ({
                     <InfoBox type={type}>
                       {training.image && (
                         <Image
-                          src={training.image || SMALL_CLASSROOM}
+                          src={training.image}
                           width="100%"
                           alt="React GraphQL Academy coach Alex assists a student, being next to them, inspecting their code and helping them on their learning path."
                         />


### PR DESCRIPTION
There is a weird image swap on the header training instance page. I think we should remove the default image until finding a better solution for that. So now it's either no image by default or it's the specific image of that instance