### PR TITLE
Show all one day react workshops correctly

### DIFF
--- a/src/components/curriculum/CurriculumReactWorkshops.js
+++ b/src/components/curriculum/CurriculumReactWorkshops.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Section from './CurriculumSection'
 import { Col, Row } from '../layout/Grid'
 import Link from '../navigation/Link'
-import { ONE_DAY_WORKSHOP } from '../../config/data'
+import { ONE_DAY_WORKSHOP, REACT_WORKSHOP } from '../../config/data'
 import { H2Ref, H4 } from '../text'
 import selectCurriculumLayout, { LIST_TWO_COL } from './selectCurriculumLayout'
 
@@ -15,7 +15,7 @@ const CurriculumReactWorkshops = ({
   showLinkToCurriculum = false,
   trainings,
 }) => {
-  const type = ONE_DAY_WORKSHOP
+  const type = [ONE_DAY_WORKSHOP, REACT_WORKSHOP]
   const commonProps = {
     showLinkToCurriculum,
     enableToggle,

--- a/src/components/curriculum/CurriculumReactWorkshops.js
+++ b/src/components/curriculum/CurriculumReactWorkshops.js
@@ -11,7 +11,6 @@ const CurriculumReactWorkshops = ({
   layout,
   enableToggle,
   isOpen,
-  toggleNavigateTo = `/react/training/workshops`,
   showLinkToCurriculum = false,
   trainings,
 }) => {
@@ -19,7 +18,6 @@ const CurriculumReactWorkshops = ({
   const commonProps = {
     showLinkToCurriculum,
     enableToggle,
-    toggleNavigateTo,
     type,
     isOpen,
     trainings,
@@ -33,6 +31,7 @@ const CurriculumReactWorkshops = ({
         name="styling"
         subTitle="See how React can look gorgeous and encourage design consistency"
         showLinkToCurriculum
+        toggleNavigateTo="/react/training/workshops/design-system-styling-in-react/london/"
       />
 
       <Section
@@ -41,6 +40,7 @@ const CurriculumReactWorkshops = ({
         name="fundamentals"
         subTitle="Learn the basics of React and jumpstart your way into a new coding ecosystem"
         showLinkToCurriculum
+        toggleNavigateTo="/react/training/react-fundamentals/london/"
       />
       <Section
         {...commonProps}
@@ -48,6 +48,7 @@ const CurriculumReactWorkshops = ({
         name="hooksAndSuspense"
         subTitle="Learn 2 of the newest and most exciting features in React"
         showLinkToCurriculum
+        toggleNavigateTo="/react/training/workshops/"
       />
     </React.Fragment>
   )
@@ -59,6 +60,7 @@ const CurriculumReactWorkshops = ({
         name="perfAndFP"
         subTitle="Discover best practice for permonant React apps"
         showLinkToCurriculum
+        toggleNavigateTo="/react/training/workshops/"
       />
       <Section
         {...commonProps}
@@ -66,6 +68,7 @@ const CurriculumReactWorkshops = ({
         name="reactGraphqlClient"
         subTitle="Consume GraphQL APIs in any React application"
         showLinkToCurriculum
+        toggleNavigateTo="/graphql/training/workshops/graphql-apollo-client/london/"
       />
       <Section
         {...commonProps}
@@ -73,6 +76,7 @@ const CurriculumReactWorkshops = ({
         name="testingReact"
         subTitle="Ensure consistent, reliable code across the React ecosystem"
         showLinkToCurriculum
+        toggleNavigateTo="/react/training/workshops/testing-in-react/london/"
       />
       <Section
         {...commonProps}
@@ -80,6 +84,7 @@ const CurriculumReactWorkshops = ({
         name="react-native"
         subTitle="Build upon your React knowledge and create great apps"
         showLinkToCurriculum
+        toggleNavigateTo="/react/training/workshops/"
       />
     </React.Fragment>
   )

--- a/src/components/curriculum/FullCurriculumsReact.js
+++ b/src/components/curriculum/FullCurriculumsReact.js
@@ -9,12 +9,14 @@ import {
   CurriculumAdvancedReact,
 } from './index'
 import CurriculumReactWorkshops from './CurriculumReactWorkshops'
+import { getUpcomingTrainingsByType } from '../training/UpcomingTrainings'
 import {
   REACT_BOOTCAMP,
   PART_TIME,
   ADVANCED_REACT,
   ONE_DAY_WORKSHOP,
   REACT_FUNDAMENTALS,
+  REACT_WORKSHOP,
 } from '../../config/data'
 
 class FullCurriculumsReact extends React.Component {
@@ -28,6 +30,11 @@ class FullCurriculumsReact extends React.Component {
 
   render() {
     const { trainings } = this.props
+    const allReactWorkshops = getUpcomingTrainingsByType({
+      trainings,
+      types: [ONE_DAY_WORKSHOP, REACT_WORKSHOP],
+    })
+
     const commonCurriculumProps = {
       trainings,
       showTitle: false,
@@ -64,7 +71,10 @@ class FullCurriculumsReact extends React.Component {
                   <CurriculumPartTime {...commonCurriculumProps} />
                 </ContentItem>
                 <ContentItem name={ONE_DAY_WORKSHOP}>
-                  <CurriculumReactWorkshops {...commonCurriculumProps} />
+                  <CurriculumReactWorkshops
+                    trainings={allReactWorkshops}
+                    showTitle={false}
+                  />
                 </ContentItem>
               </TabContent>
             </Tabs>

--- a/src/components/training/UpcomingTrainingSection.js
+++ b/src/components/training/UpcomingTrainingSection.js
@@ -7,10 +7,7 @@ import Grid, { Col, Row } from '../layout/Grid'
 import { H2Ref, H3, P } from '../text'
 import { TrainingItem } from './'
 import Link from '../navigation/Link'
-import {
-  selectUpcomingTrainings,
-  getUpcomingTrainingsByType,
-} from './UpcomingTrainings'
+import { getUpcomingTrainingsByType } from './UpcomingTrainings'
 import Newsletter from '../elements/Newsletter'
 import { GREY } from '../../config/styles'
 import {
@@ -31,7 +28,6 @@ import {
   GRAPHQL_BOOTCAMP,
   GRAPHQL_API,
   GRAPHQL_CLIENT,
-  GRAPHQL_WORKSHOP,
   MEETUP,
 } from '../../config/data'
 import CorporateTrainingCard from '../elements/CorporateTrainingCard'
@@ -52,7 +48,10 @@ const CorporateCrossSell = styled.div`
 `
 
 export const UpcomingTrainings = ({ curriculum, type, trainings }) => {
-  const filteredTrainings = selectUpcomingTrainings({ type, trainings })
+  const filteredTrainings = getUpcomingTrainingsByType({
+    types: [...type],
+    trainings,
+  })
   if (!filteredTrainings.length || !filteredTrainings[0].id) {
     return <P>Sorry! There are no {type} dates confirmed.</P>
   } else {


### PR DESCRIPTION
This PR is a fix for the issue of having a course type of ONE_DAY_WORKSHOP where we also need to display REACT_WORKSHOP (which they should be in future). Now on the selector for workshops on homepage and react they all appear correctly. In addition the links to instances have been updated for this particular edge case.