### PR TITLE
Add resources as separate custom field to all sign ups in order to se…

### DIFF
--- a/functions/setupApi.js
+++ b/functions/setupApi.js
@@ -57,7 +57,7 @@ const setupApi = ({ autopilotapikey, middlewares = [] }) => {
 
   async function sessionSubscribe(request, response) {
     const data = request && request.body
-    const { name, email, subscriptions } = data
+    const { name, email, subscriptions, resources, pathname } = data
     const custom = subscriptions.reduce((acc, subscription) => {
       acc[`boolean--${subscription}--Session`] = true
       return acc
@@ -66,24 +66,25 @@ const setupApi = ({ autopilotapikey, middlewares = [] }) => {
       contact: {
         FirstName: name,
         Email: email,
-        LeadSource: '1-day workshops form',
+        LeadSource: pathname,
         _autopilot_list: 'contactlist_37B9CE06-F48D-4F7B-A119-4725B474EF2C',
         custom,
+        'boolean--Resources-SingedUp': resources,
       },
     })
     response.status(200).send('it worked')
   }
 
   async function subscribe(request, response) {
-    const email = request && request.body && request.body.email
-    const pathname = request && request.body && request.body.pathname
-    const city = request && request.body && request.body.city
+    const data = request && request.body
+    const { email, pathname, city, resources } = data
     await postToAutopilot(`/contact`, {
       contact: {
         Email: email,
         LeadSource: pathname,
         custom: {
           'string--From--City': city,
+          'boolean--Resources-SingedUp': resources,
         },
       },
     })

--- a/functions/setupApi.js
+++ b/functions/setupApi.js
@@ -3,6 +3,7 @@ const express = require('express')
 
 const setupApi = ({ autopilotapikey, middlewares = [] }) => {
   const api = express()
+  const RESOURCES_SINGED_UP = 'boolean--Resources-SingedUp'
   middlewares.map(middleware => api.use(middleware))
 
   api.use(setOptions)
@@ -69,7 +70,7 @@ const setupApi = ({ autopilotapikey, middlewares = [] }) => {
         LeadSource: pathname,
         _autopilot_list: 'contactlist_37B9CE06-F48D-4F7B-A119-4725B474EF2C',
         custom,
-        'boolean--Resources-SingedUp': resources,
+        [RESOURCES_SINGED_UP]: resources,
       },
     })
     response.status(200).send('it worked')
@@ -84,7 +85,7 @@ const setupApi = ({ autopilotapikey, middlewares = [] }) => {
         LeadSource: pathname,
         custom: {
           'string--From--City': city,
-          'boolean--Resources-SingedUp': resources,
+          [RESOURCES_SINGED_UP]: resources,
         },
       },
     })

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,12 @@
 import trackUserBehaviour from '../components/utils/trackUserBehaviour'
 
-export const triggerSessionSubscribe = ({ name, email, subscriptions }) =>
+export const triggerSessionSubscribe = ({
+  name,
+  email,
+  subscriptions,
+  resources,
+  pathname = '1-day workshops form',
+}) =>
   fetch(
     `https://us-central1-reactgraphqlacademy.cloudfunctions.net/api/sessionSubscribe`,
     {
@@ -12,6 +18,8 @@ export const triggerSessionSubscribe = ({ name, email, subscriptions }) =>
         name,
         email,
         subscriptions,
+        resources,
+        pathname,
       }),
     }
   ).then(() => {
@@ -38,7 +46,12 @@ export const triggerUnsubscribe = ({ email }) =>
     })
   })
 
-export const triggerSubscribe = ({ email, pathname = 'footer', city }) =>
+export const triggerSubscribe = ({
+  email,
+  pathname = 'footer',
+  city,
+  resources = true,
+}) =>
   fetch(
     `https://us-central1-reactgraphqlacademy.cloudfunctions.net/api/subscribe`,
     {
@@ -50,6 +63,7 @@ export const triggerSubscribe = ({ email, pathname = 'footer', city }) =>
         email,
         pathname,
         city,
+        resources,
       }),
     }
   ).then(() => {

--- a/src/pages/react/training/workshops/interest-form.js
+++ b/src/pages/react/training/workshops/interest-form.js
@@ -33,11 +33,13 @@ const NameInput = aliasComponent(InputField)
 const SessionInterest = () => (
   <Layout>
     {({ trainings }) => {
-      const handleFormSubmit = ({ name, email, subscriptions }) => {
+      const handleFormSubmit = ({ name, email, subscriptions, resources }) => {
         triggerSessionSubscribe({
           name,
           email,
           subscriptions: Object.keys(subscriptions),
+          resources,
+          pathname: 'React 1 day workshops form',
         })
         navigate('/thanks-for-signing-up-for-sessions')
       }
@@ -153,7 +155,7 @@ const SessionInterest = () => (
                                   them!{' '}
                                 </P>
                                 <CheckboxField
-                                  name="subscriptions.resources"
+                                  name="resources"
                                   label="I want free learning resources!"
                                 />
                               </Col>


### PR DESCRIPTION
Following an AP session to look at the current issues with AP, this PR adds resources permissions as separate custom field to all sign ups in order to be able to segment in AP journey's to solve the issue we have with the Pipe Drive integration. We need to segment by a custom field and not rely on just the "email permission" moving forward otherwise we end up with many unexpected people in the resources journey. 

I also standardized the use of the pathname arg to donate LeadSource in the `sessionSubscribe` function so it follows the same convention as the `subscribe`