### PR TITLE
removes prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "gatsby-transformer-remark": "^2.3.12",
     "markdown-to-jsx": "^6.10.2",
     "payment": "^2.3.0",
-    "prop-types": "^15.6.2",
     "raven-js": "^3.26.4",
     "react": "^16.8.6",
     "react-apollo": "^2.1.9",

--- a/src/components/curriculum/CurriculumAdvancedReact.js
+++ b/src/components/curriculum/CurriculumAdvancedReact.js
@@ -14,7 +14,6 @@ import { ADVANCED_REACT } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
 import { Li } from '../layout/Ul'
 import { trainingTime } from '../utils'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumAdvancedReact = ({
   showTitle = true,
@@ -138,7 +137,6 @@ const LearningObjectivesList = () => (
   </React.Fragment>
 )
 
-CurriculumAdvancedReact.propTypes = curriculumCommonPropTypes
 CurriculumAdvancedReact.LearningObjectivesList = LearningObjectivesList
 CurriculumAdvancedReact.TargetAudienceList = TargetAudienceList
 

--- a/src/components/curriculum/CurriculumCorporateGraphQL.js
+++ b/src/components/curriculum/CurriculumCorporateGraphQL.js
@@ -3,7 +3,6 @@ import Section, { curriedToggleNavigateTo } from './CurriculumSection'
 import { LinkButton } from '../buttons'
 import { GRAPHQL_BOOTCAMP } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumCorporateGraphQL = ({
   layout,
@@ -71,7 +70,5 @@ const CurriculumCorporateGraphQL = ({
     corpTrainingFacts: true,
   })
 }
-
-CurriculumCorporateGraphQL.propTypes = curriculumCommonPropTypes
 
 export default CurriculumCorporateGraphQL

--- a/src/components/curriculum/CurriculumCorporateReact.js
+++ b/src/components/curriculum/CurriculumCorporateReact.js
@@ -3,7 +3,6 @@ import Section, { curriedToggleNavigateTo } from './CurriculumSection'
 import { LinkButton } from '../buttons'
 import { REACT_BOOTCAMP } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumCorporateReact = ({
   layout,
@@ -71,7 +70,5 @@ const CurriculumCorporateReact = ({
     corpTrainingFacts: true,
   })
 }
-
-CurriculumCorporateReact.propTypes = curriculumCommonPropTypes
 
 export default CurriculumCorporateReact

--- a/src/components/curriculum/CurriculumGraphQLAPI.js
+++ b/src/components/curriculum/CurriculumGraphQLAPI.js
@@ -7,7 +7,6 @@ import NodejsSession from './sessions/NodejsSession'
 // import GraphQLServerDayTwoSessions from './sessions/GraphQLServerDayTwoSessions'
 import { GRAPHQL_API } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumGraphQLAPI = ({
   showTitle = true,
@@ -82,7 +81,5 @@ const CurriculumGraphQLAPI = ({
     curriculumTo: showLinkToCurriculum ? toggleNavigateTo : undefined,
   })
 }
-
-CurriculumGraphQLAPI.propTypes = curriculumCommonPropTypes
 
 export default CurriculumGraphQLAPI

--- a/src/components/curriculum/CurriculumGraphQLBootcamp.js
+++ b/src/components/curriculum/CurriculumGraphQLBootcamp.js
@@ -8,7 +8,6 @@ import NodejsSession from './sessions/NodejsSession'
 import GraphQLApolloClientDaySessions from './sessions/GraphQLApolloClientDaySessions'
 import { GRAPHQL_BOOTCAMP } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumGraphQLBootcamp = ({
   showTitle = true,
@@ -89,7 +88,5 @@ const CurriculumGraphQLBootcamp = ({
     curriculumTo: showLinkToCurriculum ? toggleNavigateTo : undefined,
   })
 }
-
-CurriculumGraphQLBootcamp.propTypes = curriculumCommonPropTypes
 
 export default CurriculumGraphQLBootcamp

--- a/src/components/curriculum/CurriculumGraphQLWorkshops.js
+++ b/src/components/curriculum/CurriculumGraphQLWorkshops.js
@@ -2,7 +2,6 @@ import React from 'react'
 import Section from './CurriculumSection'
 import { GRAPHQL_WORKSHOP, GRAPHQL_CLIENT } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumGraphQLWorkshops = ({
   showTitle = true,
@@ -59,7 +58,5 @@ const CurriculumGraphQLWorkshops = ({
     curriculumTo: showLinkToCurriculum ? toggleNavigateTo : undefined,
   })
 }
-
-CurriculumGraphQLWorkshops.propsTypes = curriculumCommonPropTypes
 
 export default CurriculumGraphQLWorkshops

--- a/src/components/curriculum/CurriculumPartTime.js
+++ b/src/components/curriculum/CurriculumPartTime.js
@@ -15,7 +15,6 @@ import HooksSession from './sessions/HooksSession'
 import { PART_TIME } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
 import { TargetAudienceList } from './CurriculumReactFundamentals'
-import { curriculumCommonPropTypes } from './'
 
 const PartTimeFinalProject = () => (
   <Ul>
@@ -167,7 +166,6 @@ export const LearningObjectivesList = () => (
   </React.Fragment>
 )
 
-CurriculumPartTime.propTypes = curriculumCommonPropTypes
 CurriculumPartTime.LearningObjectivesList = LearningObjectivesList
 CurriculumPartTime.TargetAudienceList = TargetAudienceList
 

--- a/src/components/curriculum/CurriculumReactBootcamp.js
+++ b/src/components/curriculum/CurriculumReactBootcamp.js
@@ -25,7 +25,6 @@ import { REACT_BOOTCAMP } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
 import { trainingTime } from '../utils'
 import CurriculumAdvancedReact from './CurriculumAdvancedReact'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumReactBootcamp = ({
   showTitle = true,
@@ -183,7 +182,6 @@ export const LearningObjectivesList = () => (
   </React.Fragment>
 )
 
-CurriculumReactBootcamp.propTypes = curriculumCommonPropTypes
 CurriculumReactBootcamp.LearningObjectivesList = LearningObjectivesList
 CurriculumReactBootcamp.TargetAudienceList = TargetAudienceList
 

--- a/src/components/curriculum/CurriculumReactFundamentals.js
+++ b/src/components/curriculum/CurriculumReactFundamentals.js
@@ -16,7 +16,6 @@ import { trainingTime } from '../utils'
 
 import { REACT_FUNDAMENTALS } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumReactFundamentals = ({
   showTitle = true,
@@ -139,7 +138,6 @@ export const LearningObjectivesList = () => (
   </React.Fragment>
 )
 
-CurriculumReactFundamentals.propTypes = curriculumCommonPropTypes
 CurriculumReactFundamentals.LearningObjectivesList = LearningObjectivesList
 CurriculumReactFundamentals.TargetAudienceList = TargetAudienceList
 

--- a/src/components/curriculum/CurriculumReactNative.js
+++ b/src/components/curriculum/CurriculumReactNative.js
@@ -14,7 +14,6 @@ import ReactNativeProductionSession from './sessions/native/ReactNativeProductio
 
 import { REACT_NATIVE } from '../../config/data'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumReactNative = ({
   showTitle = true,
@@ -92,7 +91,5 @@ const CurriculumReactNative = ({
     curriculumTo: showLinkToCurriculum ? toggleNavigateTo : undefined,
   })
 }
-
-CurriculumReactNative.propTypes = curriculumCommonPropTypes
 
 export default CurriculumReactNative

--- a/src/components/curriculum/CurriculumReactWorkshops.js
+++ b/src/components/curriculum/CurriculumReactWorkshops.js
@@ -4,7 +4,6 @@ import Link from '../navigation/Link'
 import { ONE_DAY_WORKSHOP, REACT_WORKSHOP } from '../../config/data'
 import { H2Ref } from '../text'
 import selectCurriculumLayout from './selectCurriculumLayout'
-import { curriculumCommonPropTypes } from './'
 
 const CurriculumReactWorkshops = ({
   showTitle = true,
@@ -106,7 +105,5 @@ const CurriculumReactWorkshops = ({
     trainings,
   })
 }
-
-CurriculumReactWorkshops.propTypes = curriculumCommonPropTypes
 
 export default CurriculumReactWorkshops

--- a/src/components/curriculum/CurriculumSection.js
+++ b/src/components/curriculum/CurriculumSection.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { H4 } from '../text'
 import { PINK } from '../../config/styles'
@@ -136,17 +135,5 @@ const CurriculumSection = props => {
 
 const addFullStopAtTheEnd = text =>
   text && text.replace ? text.replace(/([^.])$/, '$1.') : ''
-
-CurriculumSection.propTypes = {
-  isOpen: PropTypes.bool,
-  title: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  name: PropTypes.string,
-  subTitle: PropTypes.string,
-  trainingTime: PropTypes.string,
-  enableToggle: PropTypes.bool,
-  toggleNavigateTo: PropTypes.func,
-  showLinkToCurriculum: PropTypes.bool,
-}
 
 export default CurriculumSection

--- a/src/components/curriculum/FullCurriculumsGraphQL.js
+++ b/src/components/curriculum/FullCurriculumsGraphQL.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Col, Row } from '../layout/Grid'
 import { H4 } from '../text'
 import { Tabs, TabList, TabItem, TabContent, ContentItem } from '../layout/Tabs'
@@ -56,10 +55,6 @@ const FullCurriculumsGraphQL = ({ trainings }) => {
       </Tabs>
     </React.Fragment>
   )
-}
-
-FullCurriculumsGraphQL.propTypes = {
-  trainings: PropTypes.array,
 }
 
 export default FullCurriculumsGraphQL

--- a/src/components/curriculum/FullCurriculumsReact.js
+++ b/src/components/curriculum/FullCurriculumsReact.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import { Col, Row } from '../layout/Grid'
 import { H4 } from '../text'
@@ -70,10 +69,6 @@ const FullCurriculumsReact = ({ trainings }) => {
       </Tabs>
     </React.Fragment>
   )
-}
-
-FullCurriculumsReact.propTypes = {
-  trainings: PropTypes.array,
 }
 
 export default FullCurriculumsReact

--- a/src/components/curriculum/index.js
+++ b/src/components/curriculum/index.js
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types'
-
 import CurriculumReactBootcamp from './CurriculumReactBootcamp'
 import CurriculumPartTime from './CurriculumPartTime'
 import CurriculumReactNative from './CurriculumReactNative'
@@ -26,16 +24,4 @@ export {
   CurriculumReactFundamentals,
   CurriculumGraphQLWorkshops,
   FullCurriculumsGraphQL,
-}
-
-export const curriculumCommonPropTypes = {
-  showTitle: PropTypes.bool,
-  isOpen: PropTypes.bool,
-  enableToggle: PropTypes.bool,
-  toggleNavigateTo: PropTypes.string,
-  marketingCard: PropTypes.object,
-  showLinkToCurriculum: PropTypes.bool,
-  layout: PropTypes.object,
-  trainings: PropTypes.array,
-  training: PropTypes.object,
 }

--- a/src/components/elements/Image.js
+++ b/src/components/elements/Image.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import withLazyLoad from './withLazyLoad'
@@ -11,11 +10,6 @@ const Image = styled(Box)`
 Image.defaultProps = {
   mt: 0,
   box: 'img',
-}
-
-Image.propTypes = {
-  src: PropTypes.string.isRequired,
-  circle: PropTypes.bool,
 }
 
 export default withLazyLoad()(Image)

--- a/src/components/elements/Video.js
+++ b/src/components/elements/Video.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import withLazyLoad from './withLazyLoad'
 
@@ -29,9 +28,5 @@ const Video = ({ youtubeId, time, description, height = '390' }) => (
     {description ? <div>{description}</div> : null}
   </IframeWrapper>
 )
-
-Video.propTypes = {
-  youtubeId: PropTypes.string.isRequired,
-}
 
 export default withLazyLoad()(Video)

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import styled from 'styled-components'
+
 import Tick from './Tick'
 import FacebookIcon from './FacebookIcon'
 import ExternalLinkIcon from './ExternalLinkIcon'
@@ -7,9 +9,6 @@ import GitHubIcon from './GitHubIcon'
 import InstagramIcon from './InstagramIcon'
 import PdfDownload from './PdfDownload'
 import LinkedinIcon from './LinkedinIcon'
-
-import PropTypes from 'prop-types'
-import styled from 'styled-components'
 
 export const StyledIcon = styled.div`
   display: inline-block;
@@ -38,10 +37,6 @@ export const StyledIcon = styled.div`
 const BulletIcon = ({ icon, social, ...rest }) => (
   <StyledIcon social={social}>{React.createElement(icon, rest)}</StyledIcon>
 )
-
-BulletIcon.propTypes = {
-  icon: PropTypes.func.isRequired,
-}
 
 export {
   ExternalLinkIcon,

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Helmet from 'react-helmet'
 import { StaticQuery, graphql } from 'gatsby'
@@ -446,15 +445,5 @@ const Header = ({
 export const RootHeader = props => (
   <Header bgColors={[GRAPHQL_PINK, BLUE]} bgImageOpacity={0.3} {...props} />
 )
-
-Header.propTypes = {
-  titleLines: PropTypes.array.isRequired,
-  subtitle: PropTypes.string,
-  links: PropTypes.array,
-  height: PropTypes.number,
-  bgImg: PropTypes.string,
-  training: PropTypes.object,
-  bgImgUrl: PropTypes.string,
-}
 
 export default withWidth()(Header)

--- a/src/components/logos/ASOS.js
+++ b/src/components/logos/ASOS.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const ASOS = ({ colour = '#0B0B0A', width, height }) => (
   <svg
@@ -15,11 +14,5 @@ const ASOS = ({ colour = '#0B0B0A', width, height }) => (
     />
   </svg>
 )
-
-ASOS.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
 
 export default ASOS

--- a/src/components/logos/Capgemini.js
+++ b/src/components/logos/Capgemini.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const Capgemini = ({
   colour = '#12ABDB',
@@ -25,12 +24,5 @@ const Capgemini = ({
     </g>
   </svg>
 )
-
-Capgemini.propTypes = {
-  colour: PropTypes.string,
-  secColour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
 
 export default Capgemini

--- a/src/components/logos/FinancialTimes.js
+++ b/src/components/logos/FinancialTimes.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const FinancialTimes = ({ colour = '#231F20', width, height, className }) => (
   <svg
@@ -16,9 +15,5 @@ const FinancialTimes = ({ colour = '#231F20', width, height, className }) => (
     />
   </svg>
 )
-FinancialTimes.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
+
 export default FinancialTimes

--- a/src/components/logos/IBM.js
+++ b/src/components/logos/IBM.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const IBM = ({ colour = '#00d5b5', width, height }) => (
   <svg viewBox="0 0 1054 500" width={width} height={height}>
@@ -20,12 +19,5 @@ const IBM = ({ colour = '#00d5b5', width, height }) => (
     />
   </svg>
 )
-
-IBM.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-  y: PropTypes.number,
-}
 
 export default IBM

--- a/src/components/logos/IKEA.js
+++ b/src/components/logos/IKEA.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+
 // -181 -110 1059 511
 const IKEA = ({ colour = '#231F20', width, height }) => (
   <svg
@@ -15,9 +15,5 @@ const IKEA = ({ colour = '#231F20', width, height }) => (
     />
   </svg>
 )
-IKEA.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
+
 export default IKEA

--- a/src/components/logos/JohnLewis.js
+++ b/src/components/logos/JohnLewis.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const JohnLewis = ({ colour = '#003e24', width, height }) => (
   <svg
@@ -112,11 +111,5 @@ const JohnLewis = ({ colour = '#003e24', width, height }) => (
     </g>
   </svg>
 )
-
-JohnLewis.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
 
 export default JohnLewis

--- a/src/components/logos/Microsoft.js
+++ b/src/components/logos/Microsoft.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const Microsoft = ({ colour = '#231F20', width, height }) => (
   <svg
@@ -55,9 +54,5 @@ const Microsoft = ({ colour = '#231F20', width, height }) => (
     />
   </svg>
 )
-Microsoft.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
+
 export default Microsoft

--- a/src/components/logos/SainBurys.js
+++ b/src/components/logos/SainBurys.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const SainBurys = ({ colour = '#f47320', width, height }) => (
   <svg
@@ -14,11 +13,5 @@ const SainBurys = ({ colour = '#f47320', width, height }) => (
     />
   </svg>
 )
-
-SainBurys.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
 
 export default SainBurys

--- a/src/components/logos/Telegraph.js
+++ b/src/components/logos/Telegraph.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const Telegraph = ({ colour = '#1d1d1b', width, height }) => (
   <svg
@@ -14,11 +13,5 @@ const Telegraph = ({ colour = '#1d1d1b', width, height }) => (
     />
   </svg>
 )
-
-Telegraph.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
 
 export default Telegraph

--- a/src/components/logos/Tesco.js
+++ b/src/components/logos/Tesco.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const Tesco = ({
   colour = '#0054a4',
@@ -36,13 +35,5 @@ const Tesco = ({
     </g>
   </svg>
 )
-
-Tesco.propTypes = {
-  colour: PropTypes.string,
-  secColour: PropTypes.string,
-  stroke: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-}
 
 export default Tesco

--- a/src/components/logos/Trainline.js
+++ b/src/components/logos/Trainline.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const Trainline = ({ colour = '#00d5b5', width, height, y }) => (
   <svg
@@ -14,12 +13,5 @@ const Trainline = ({ colour = '#00d5b5', width, height, y }) => (
     />
   </svg>
 )
-
-Trainline.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-  y: PropTypes.number,
-}
 
 export default Trainline

--- a/src/components/logos/Xing.js
+++ b/src/components/logos/Xing.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const Xing = ({ colour = '#00d5b5', width, height, y }) => (
   <svg
@@ -14,12 +13,5 @@ const Xing = ({ colour = '#00d5b5', width, height, y }) => (
     />
   </svg>
 )
-
-Xing.propTypes = {
-  colour: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-  y: PropTypes.number,
-}
 
 export default Xing

--- a/src/components/navigation/menu/PhoneMenu/ToggleButton.js
+++ b/src/components/navigation/menu/PhoneMenu/ToggleButton.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+
 import styled from 'styled-components'
 
 import { WHITE, FONT_FAMILY } from '../../../../config/styles'
@@ -90,11 +90,5 @@ const StyledToggleButton = styled(ToggleButton)`
     transform: rotate(-45deg) translate(3px, 4px);
   }
 `
-
-StyledToggleButton.propTypes = {
-  toggleMenu: PropTypes.func.isRequired,
-  isOpen: PropTypes.bool.isRequired,
-  className: PropTypes.string,
-}
 
 export default StyledToggleButton

--- a/src/components/navigation/menu/PhoneMenu/index.js
+++ b/src/components/navigation/menu/PhoneMenu/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import PropTypes from 'prop-types'
+
 import styled from 'styled-components'
 
 import Link from '../../Link'
@@ -50,10 +50,6 @@ export const MenuContent = styled.div`
     margin-bottom: 15px;
   }
 `
-MenuContent.propTypes = {
-  isOpen: PropTypes.bool.isRequired,
-  width: PropTypes.number.isRequired,
-}
 
 const PhoneMenu = ({ width, defaultIsOpen = false }) => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen)
@@ -91,11 +87,6 @@ const PhoneMenu = ({ width, defaultIsOpen = false }) => {
       </MenuContent>
     </React.Fragment>
   )
-}
-
-PhoneMenu.propTypes = {
-  defaultIsOpen: PropTypes.bool,
-  width: PropTypes.number,
 }
 
 PhoneMenu.defaultProps = {

--- a/src/components/navigation/menu/index.js
+++ b/src/components/navigation/menu/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import PropTypes from 'prop-types'
 
 import withWidth, { MEDIUM } from '../../utils/WithWidth'
 import RGALogo from '../../logos/RGALogo'
@@ -54,10 +53,6 @@ export const Menu = ({ width }) => {
       </Grid>
     </Navbar>
   )
-}
-
-Menu.propTypes = {
-  width: PropTypes.number,
 }
 
 export default withWidth()(Menu)

--- a/src/components/payment/Countdown.js
+++ b/src/components/payment/Countdown.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+
 import { Col, Row } from '../layout/Grid.js'
 import Span from '../text/Span.js'
 import styled from 'styled-components'
@@ -127,10 +127,6 @@ class Countdown extends Component {
       </React.Fragment>
     )
   }
-}
-
-Countdown.propTypes = {
-  date: PropTypes.object.isRequired,
 }
 
 Countdown.defaultProps = {

--- a/src/components/payment/PaymentSection.js
+++ b/src/components/payment/PaymentSection.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+
 import { withApollo } from 'react-apollo'
 import { graphql, compose } from 'react-apollo'
 import { navigate } from 'gatsby'
@@ -286,17 +286,6 @@ class PaymentSection extends React.Component {
 PaymentSection.defaultProps = {
   trackUserBehaviour,
   navigate,
-}
-
-PaymentSection.propTypes = {
-  trainingError: PropTypes.bool,
-  trainingLoading: PropTypes.bool,
-  training: PropTypes.object,
-  data: PropTypes.object,
-  paymentApi: PropTypes.object,
-  city: PropTypes.string,
-  navigate: PropTypes.func,
-  financeAvailable: PropTypes.bool,
 }
 
 const withUpcomingVouchers = graphql(PAYMENT_SECTION_QUERY, {

--- a/src/components/payment/checkout/CheckoutContainer.js
+++ b/src/components/payment/checkout/CheckoutContainer.js
@@ -1,7 +1,7 @@
 /* eslint no-undef: 0 */
 
 import React from 'react'
-import PropTypes from 'prop-types'
+
 import { graphql, withApollo } from 'react-apollo'
 
 import PAY from './Pay.graphql'
@@ -228,28 +228,6 @@ export class CheckoutContainer extends React.Component {
 CheckoutContainer.defaultProps = {
   trackUserBehaviour,
   triggerSubscribe,
-}
-
-CheckoutContainer.propTypes = {
-  pay: PropTypes.func.isRequired,
-  vatRate: PropTypes.number.isRequired,
-  addCourse: PropTypes.func.isRequired,
-  removeCourse: PropTypes.func.isRequired,
-  client: PropTypes.object.isRequired,
-  updateVatRate: PropTypes.func.isRequired,
-  quantity: PropTypes.number.isRequired,
-  currentPriceQuantity: PropTypes.number.isRequired,
-  priceQuantity: PropTypes.number.isRequired,
-  trainingInstanceId: PropTypes.string,
-  eventId: PropTypes.string,
-  trackUserBehaviour: PropTypes.func.isRequired,
-  resetVoucher: PropTypes.func.isRequired,
-  validateVoucher: PropTypes.func.isRequired,
-  voucher: PropTypes.string.isRequired,
-  isVoucherValid: PropTypes.bool,
-  isVoucherValidationInProgress: PropTypes.bool.isRequired,
-  paymentApi: PropTypes.object,
-  navigate: PropTypes.func.isRequired,
 }
 
 const withPay = graphql(PAY, {

--- a/src/components/payment/checkout/index.js
+++ b/src/components/payment/checkout/index.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import PropTypes from 'prop-types'
+
 import styled from 'styled-components'
 import { Button } from '../../buttons'
 import { Span, P } from '../../text'
@@ -142,26 +142,4 @@ Checkout.defaultProps = {
   trackUserBehaviour,
 }
 
-Checkout.propTypes = {
-  navigate: PropTypes.func.isRequired,
-  trainingInstanceId: PropTypes.string,
-  eventId: PropTypes.string,
-  vatRate: PropTypes.number.isRequired,
-  updateVatRate: PropTypes.func.isRequired,
-  currency: PropTypes.string.isRequired,
-  price: PropTypes.number.isRequired,
-  discountPrice: PropTypes.number,
-  quantity: PropTypes.number.isRequired,
-  priceQuantity: PropTypes.number,
-  currentPriceQuantity: PropTypes.number.isRequired,
-  removeCourse: PropTypes.func.isRequired,
-  addCourse: PropTypes.func.isRequired,
-  resetVoucher: PropTypes.func.isRequired,
-  validateVoucher: PropTypes.func.isRequired,
-  voucher: PropTypes.string.isRequired,
-  isVoucherValid: PropTypes.bool,
-  isVoucherValidationInProgress: PropTypes.bool.isRequired,
-  paymentApi: PropTypes.object,
-  city: PropTypes.string,
-}
 export default Checkout

--- a/src/components/training/TrainingCard.js
+++ b/src/components/training/TrainingCard.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+
 import styled from 'styled-components'
 
 import { DARK_GREY } from '../../config/styles'
@@ -17,9 +17,6 @@ const TrainingCard = styled(Flex)`
 `
 
 TrainingCard.displayName = 'TrainingCard'
-TrainingCard.propTypes = {
-  color: PropTypes.string,
-}
 
 TrainingCard.defaultProps = {
   mt: 0,

--- a/src/components/utils/WithWidth.js
+++ b/src/components/utils/WithWidth.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 export const EXTRA_LARGE = 4,
   LARGE = 3,
@@ -86,18 +85,6 @@ export class Width extends React.Component {
   }
 }
 
-Width.propTypes = {
-  extraLargeWidth: PropTypes.number,
-  largeWidth: PropTypes.number,
-  mediumWidth: PropTypes.number,
-  smallWidth: PropTypes.number,
-  resizeInterval: PropTypes.number,
-}
-
-Width.contextTypes = {
-  width: PropTypes.object,
-}
-
 const withWidth = (options = {}) => OuterComponent => {
   const {
     extraLargeWidth,
@@ -123,10 +110,6 @@ const withWidth = (options = {}) => OuterComponent => {
     render() {
       return <OuterComponent {...this.props} width={this.state.width} />
     }
-  }
-
-  WithWidth.contextTypes = {
-    width: PropTypes.object,
   }
 
   return WithWidth

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,6 +2856,7 @@ as-array@^2.0.0:
 asap@^2.0.3, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 ascli@~1:
   version "1.0.1"
@@ -5260,6 +5261,7 @@ core-js@3.0.1:
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.0.0, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.7, core-js@^2.6.5:
   version "2.6.9"
@@ -6312,6 +6314,7 @@ encodeurl@~1.0.2:
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
   dependencies:
     iconv-lite "~0.4.13"
 
@@ -7237,6 +7240,7 @@ fbjs-css-vars@^1.0.0:
 fbjs@^0.8.0, fbjs@^0.8.1:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -8818,6 +8822,7 @@ gtoken@^2.3.0:
 gud@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -10046,6 +10051,7 @@ is-stream-ended@^0.1.0, is-stream-ended@^0.1.4:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-string@^1.0.4:
   version "1.0.4"
@@ -10592,6 +10598,7 @@ js-levenshtein@^1.1.3:
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -11376,6 +11383,7 @@ longest@^1.0.0:
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
@@ -12133,6 +12141,7 @@ node-fetch@2.3.0:
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -12387,6 +12396,7 @@ object-assign@^3.0.0:
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-component@0.0.3:
   version "0.0.3"
@@ -13761,6 +13771,7 @@ promise.prototype.finally@^3.1.0:
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
   dependencies:
     asap "~2.0.3"
 
@@ -14388,6 +14399,7 @@ react-styled-flexboxgrid@^3.1.0:
 react-super-responsive-table@^4.3.11:
   version "4.3.12"
   resolved "https://registry.yarnpkg.com/react-super-responsive-table/-/react-super-responsive-table-4.3.12.tgz#dca35d75197fd5ffa8e07f733e68196955e3341f"
+  integrity sha512-78DQY0AhaGabzRGMz6n/hDWTesfRqCD7tfppmCv7k92vccek/cSnmfNhpd4S0mjRGuINxnO+uA+i1eJMnBe6mg==
   dependencies:
     create-react-context "^0.2.3"
 
@@ -15199,6 +15211,7 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 sane@^2.0.0:
   version "2.5.2"
@@ -16820,6 +16833,7 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.18:
   version "0.7.20"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
+  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
 uglify-js@3.4.x:
   version "3.4.10"
@@ -17550,6 +17564,7 @@ whatwg-fetch@2.0.4:
 whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
We want to make the production build as fast as possible and we are removing any code that is not run in production. The prop-types library is tiny 1Kb but there is a certain amount of JS that is left in the build and evaluated on the browser, for instance:
```
CheckoutContainer.propTypes = {
  pay: PropTypes.func.isRequired,
  vatRate: PropTypes.number.isRequired,
  addCourse: PropTypes.func.isRequired,
  removeCourse: PropTypes.func.isRequired,
  client: PropTypes.object.isRequired,
  updateVatRate: PropTypes.func.isRequired,
  quantity: PropTypes.number.isRequired,
  currentPriceQuantity: PropTypes.number.isRequired,
  priceQuantity: PropTypes.number.isRequired,
  trainingInstanceId: PropTypes.string,
  eventId: PropTypes.string,
  trackUserBehaviour: PropTypes.func.isRequired,
  resetVoucher: PropTypes.func.isRequired,
  validateVoucher: PropTypes.func.isRequired,
  voucher: PropTypes.string.isRequired,
  isVoucherValid: PropTypes.bool,
  isVoucherValidationInProgress: PropTypes.bool.isRequired,
  paymentApi: PropTypes.object,
  navigate: PropTypes.func.isRequired,
}
```
Another reason to remove prop-types from this project is that we recommend to use TypeScript for type checking instead of prop types and we use this project as a reference for students to see how we use React in the real-world.